### PR TITLE
Bugfix: work again on current (2017) browsers without MediaStreamTrack.getSources

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ AFRAME.registerComponent('passthrough', {
       setupCanvas(videoSourceId);
     }
 
-    if(MediaStreamTrack) {
+    if(MediaStreamTrack && MediaStreamTrack.getSources) {
       MediaStreamTrack.getSources(withBackCamera);
     } else {
       setupCanvas(null);


### PR DESCRIPTION
MediaStreamTrack.getSources has been deprecated for "ages" (e.g., like six months in the fast moving world of web technologies) and doesn't even exist anymore in current browsers.

This just checks that it exists, and otherwise goes down the other code path which still seems to work.